### PR TITLE
Add RDN attributes only when slice is not nil

### DIFF
--- a/ldap/resource_entry.go
+++ b/ldap/resource_entry.go
@@ -84,7 +84,9 @@ func resourceLDAPEntryRead(_ context.Context, d *schema.ResourceData, m interfac
 		return diag.FromErr(err)
 	}
 	ignoreRDNAttributes := client.GetRDNAttributes(ldapEntry, id)
-	*ignoreAndBase64Encode.IgnoreAttributes = append(*ignoreAndBase64Encode.IgnoreAttributes, *ignoreRDNAttributes...)
+	if ignoreRDNAttributes != nil {
+		*ignoreAndBase64Encode.IgnoreAttributes = append(*ignoreAndBase64Encode.IgnoreAttributes, *ignoreRDNAttributes...)
+	}
 	client.IgnoreAndBase64encodeAttributes(ldapEntry, ignoreAndBase64Encode)
 
 	err = d.Set(attributeNameDn, id)


### PR DESCRIPTION
When there are no DN attributes in the ldap_object, the provider crashes with a nil pointer dereference.
This PR is to fix this case.