### PR TITLE
Adding the ability to explicitly specify attributes for the ldap_entry resource

### DIFF
--- a/docs/resources/entry.md
+++ b/docs/resources/entry.md
@@ -58,6 +58,7 @@ resource "ldap_entry" "user_example" {
 - `case_sensitive_attribute_names` (List of String) list of attributes with case-sensitive names
 - `ignore_attribute_patterns` (List of String) list of attribute patterns to ignore
 - `ignore_attributes` (List of String) list of attributes to ignore
+- `restrict_attributes` (List of String) list of attributes to which operating is restricted. Defaults to `*`, which means 'all user attributes'. It can also contain operational attributes.
 
 ### Read-Only
 

--- a/docs/resources/entry.md
+++ b/docs/resources/entry.md
@@ -58,7 +58,7 @@ resource "ldap_entry" "user_example" {
 - `case_sensitive_attribute_names` (List of String) list of attributes with case-sensitive names
 - `ignore_attribute_patterns` (List of String) list of attribute patterns to ignore
 - `ignore_attributes` (List of String) list of attributes to ignore
-- `restrict_attributes` (List of String) list of attributes to which operating is restricted. Defaults to `*`, which means 'all user attributes'. It can also contain operational attributes.
+- `restrict_attributes` (List of String) list of attributes to which operating is restricted. Defaults to '*', which means 'all user attributes'. It can also contain operational attributes.
 
 ### Read-Only
 


### PR DESCRIPTION
# Summary

The `restrict_attributes` parameter has been added to the `ldap_entry` resource, which is also used for `ldap_entry` data_source.

# What is it for

The current implementation does not allow to manage operational attributes, because they are not returned when updating the state of the resource (performed using the SEARCH operation with the value '*' in the list of attributes). This means that a value can be assigned, but when `terraform plan/apply` is executed again, this value will be ignored and added again, resulting in a response code 20 ("Attribute Or Value Exists"):

```
LDAP Result Code 20 "Attribute Or Value Exists": Entry ou=users,dc=example,dc=com cannot be modified because it would have resulted in one or more duplicate values for attribute
```

In our case, we encountered an error when adding the `aci` attribute for OU in LDAP OpenDJ, which is an operational attribute.

Example of a manifest with which the error is reproduced:
```hcl
resource "ldap_entry" "ou_users" {
  dn = "ou=users,dc=example,dc=com"
  data_json = jsonencode({
    objectClass = [
      "top",
      "organizationalunit",
    ]
    aci = [
      replace(<<-EOT
      (target="ldap:///ou=users,dc=example,dc=com")
      (targetattr="cn")
      (targetfilter="(objectClass=inetOrgPerson)")
      (version 3.0; acl "Grant access to all attrs for user1"; 
        allow (all)
        userdn="ldap:///uid=user1,ou=users,dc=example,dc=com";)
      EOT
      , "\n", "")
    ]
  })
}
```

# An example of a manifest with fix

The `restrict_attributes` parameter has been added to the `ldap_entry` resource, which explicitly defines the list of attributes that will be passed to LDAP in the SEARCH request. 

Example of the manifest:
```hcl
resource "ldap_entry" "ou_users" {
  dn = "ou=users,dc=example,dc=com"
  restrict_attributes = [
    "*",
    "aci",
  ]
  data_json = jsonencode({
    objectClass = [
      "top",
      "organizationalunit",
    ]
    aci = [
      replace(<<-EOT
      (target="ldap:///ou=users,dc=example,dc=com")
      (targetattr="cn")
      (targetfilter="(objectClass=inetOrgPerson)")
      (version 3.0; acl "Grant access to all attrs for user1"; 
        allow (all)
        userdn="ldap:///uid=user1,ou=users,dc=example,dc=com";)
      EOT
      , "\n", "")
    ]
  })
}
```

In this example, we explicitly request all user attributes + operational attribute aci.