### PR TITLE
feat: Ignore attributes on import

### DIFF
--- a/ldap/resource_entry.go
+++ b/ldap/resource_entry.go
@@ -45,6 +45,11 @@ func resourceLDAPEntry() *schema.Resource {
 					var newLdapEntry client.LdapEntry
 					json.Unmarshal([]byte(newValue), &newLdapEntry.Entry)
 
+					// Apply ignore attributes to both old and new entries
+					ignoreAndBase64Encode := getIgnoreAndBase64encode(d)
+					client.IgnoreAttributes(&oldLdapEntry, ignoreAndBase64Encode)
+					client.IgnoreAttributes(&newLdapEntry, ignoreAndBase64Encode)
+
 					attributeNamesCaseSensitive := EntryAttributeNamesCaseSensitive
 					if !attributeNamesCaseSensitive {
 						caseSensitiveAttributeList := new([]string)
@@ -147,7 +152,11 @@ func resourceLDAPEntry() *schema.Resource {
 	}
 }
 
-func resourceLDAPEntryImport(_ context.Context, d *schema.ResourceData, _ interface{}) ([]*schema.ResourceData, error) {
+func resourceLDAPEntryImport(ctx context.Context, d *schema.ResourceData, m interface{}) ([]*schema.ResourceData, error) {
+	diags := resourceLDAPEntryRead(ctx, d, m)
+	if diags.HasError() {
+		return nil, fmt.Errorf("failed to read LDAP entry during import: %s", diags[0].Summary)
+	}
 	return []*schema.ResourceData{d}, nil
 }
 


### PR DESCRIPTION
After import ldap entry I have following problem. Terraform tries to apply changes and add `ignoreAttributes`
 at the same time which leads to conflict and error on apply.

```
16:45:08.543 STDOUT terraform: Terraform will perform the following actions:
16:45:08.543 STDOUT terraform:   # ldap_entry.group["some_group"] will be updated in-place
16:45:08.543 STDOUT terraform:   ~ resource "ldap_entry" "group" {
16:45:08.543 STDOUT terraform:       ~ data_json         = jsonencode(
16:45:08.543 STDOUT terraform:           ~ {
16:45:08.543 STDOUT terraform:               - dSCorePropagationData = [
16:45:08.543 STDOUT terraform:                   - "16010101000000.0Z",
16:45:08.543 STDOUT terraform:                 ]
16:45:08.543 STDOUT terraform:               - distinguishedName     = [
16:45:08.543 STDOUT terraform:                   - "<dn>",
16:45:08.543 STDOUT terraform:                 ]
16:45:08.543 STDOUT terraform:               - groupType             = [
16:45:08.543 STDOUT terraform:                   - "-2147483646",
16:45:08.543 STDOUT terraform:                 ]
16:45:08.543 STDOUT terraform:               - instanceType          = [
16:45:08.543 STDOUT terraform:                   - "4",
16:45:08.543 STDOUT terraform:                 ]
16:45:08.543 STDOUT terraform:               - name                  = [
16:45:08.543 STDOUT terraform:                   - "<name>",
16:45:08.543 STDOUT terraform:                 ]
16:45:08.543 STDOUT terraform:               - objectCategory        = [
16:45:08.543 STDOUT terraform:                   - "<category>",
16:45:08.543 STDOUT terraform:                 ]
16:45:08.543 STDOUT terraform:               - objectGUID            = [
16:45:08.543 STDOUT terraform:                   - "<guid>",
16:45:08.543 STDOUT terraform:                 ]
16:45:08.543 STDOUT terraform:               - objectSid             = [
16:45:08.543 STDOUT terraform:                   - "<sid>",
16:45:08.543 STDOUT terraform:                 ]
16:45:08.543 STDOUT terraform:               - sAMAccountType        = [
16:45:08.544 STDOUT terraform:                   - "78768769786",
16:45:08.544 STDOUT terraform:                 ]
16:45:08.544 STDOUT terraform:               - uSNChanged            = [
16:45:08.544 STDOUT terraform:                   - "17924956",
16:45:08.544 STDOUT terraform:                 ]
16:45:08.544 STDOUT terraform:               - uSNCreated            = [
16:45:08.544 STDOUT terraform:                   - "17924956",
16:45:08.544 STDOUT terraform:                 ]
16:45:08.544 STDOUT terraform:               - whenChanged           = [
16:45:08.544 STDOUT terraform:                   - "20260323152719.0Z",
16:45:08.544 STDOUT terraform:                 ]
16:45:08.544 STDOUT terraform:               - whenCreated           = [
16:45:08.544 STDOUT terraform:                   - "20260323152719.0Z",
16:45:08.544 STDOUT terraform:                 ]
16:45:08.544 STDOUT terraform:                 # (3 unchanged attributes hidden)
16:45:08.544 STDOUT terraform:             }
16:45:08.544 STDOUT terraform:         )
16:45:08.544 STDOUT terraform:         id                = "<id>"
16:45:08.544 STDOUT terraform:       + ignore_attributes = [
16:45:08.544 STDOUT terraform:           + "dSCorePropagationData",
16:45:08.544 STDOUT terraform:           + "distinguishedName",
16:45:08.544 STDOUT terraform:           + "groupType",
16:45:08.544 STDOUT terraform:           + "instanceType",
16:45:08.544 STDOUT terraform:           + "name",
16:45:08.544 STDOUT terraform:           + "objectCategory",
16:45:08.544 STDOUT terraform:           + "objectGUID",
16:45:08.544 STDOUT terraform:           + "objectSid",
16:45:08.544 STDOUT terraform:           + "sAMAccountType",
16:45:08.544 STDOUT terraform:           + "uSNChanged",
16:45:08.544 STDOUT terraform:           + "uSNCreated",
16:45:08.544 STDOUT terraform:           + "whenChanged",
16:45:08.544 STDOUT terraform:           + "whenCreated",
16:45:08.544 STDOUT terraform:         ]
16:45:08.544 STDOUT terraform:         # (1 unchanged attribute hidden)
16:45:08.544 STDOUT terraform:     }
16:45:08.544 STDOUT terraform: Plan: 0 to add, 1 to change, 0 to destroy.
```