### PR TITLE
Add data_json_create_defaults to ldap_entry resource

### DIFF
--- a/docs/resources/entry.md
+++ b/docs/resources/entry.md
@@ -56,6 +56,7 @@ resource "ldap_entry" "user_example" {
 - `base64encode_attribute_patterns` (List of String) list of attribute patterns for base64 encoded attributes
 - `base64encode_attributes` (List of String) list of base64 encoded attributes
 - `case_sensitive_attribute_names` (List of String) list of attributes with case-sensitive names
+- `data_json_create_defaults` (String) JSON-encoded attribute values (same shape as data_json: attribute name -> list of values) injected on Create if the attribute is absent from data_json. Keys are also treated as ignore_attributes on Read and Update, so the attribute is never surfaced to state nor modified after initial creation. Intended for fields owned by an external system (e.g. a userPassword reset by Keycloak after the entry is created).
 - `ignore_attribute_patterns` (List of String) list of attribute patterns to ignore
 - `ignore_attributes` (List of String) list of attributes to ignore
 - `restrict_attributes` (List of String) list of attributes to which operating is restricted. Defaults to '*', which means 'all user attributes'. It can also contain operational attributes.

--- a/ldap/commons.go
+++ b/ldap/commons.go
@@ -11,5 +11,6 @@ const attributeNameDn = "dn"
 const attributeNameOu = "ou"
 const attributeNameCaseSensitiveAttibuteNames = "case_sensitive_attribute_names"
 const attributeNamePagingSize = "paging_size"
+const attributeNameDataJsonCreateDefaults = "data_json_create_defaults"
 
 const dummyFilter = "objectClass=*"

--- a/ldap/helpers.go
+++ b/ldap/helpers.go
@@ -1,6 +1,8 @@
 package ldap
 
 import (
+	"encoding/json"
+
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/l-with/terraform-provider-ldap/client"
 )
@@ -43,4 +45,56 @@ func getOldAttributeListFromAttribute(d *schema.ResourceData, attributeName stri
 		*oldAttributeList = append(*oldAttributeList, attributeListValue.(string))
 	}
 	return oldAttributeList
+}
+
+// parseCreateDefaults decodes the data_json_create_defaults JSON string
+// (same shape as data_json: attribute name -> list of values). An empty
+// or unparseable value yields an empty map — validation of the string is
+// handled by the schema ValidateFunc, so callers stay total.
+func parseCreateDefaults(raw interface{}) map[string][]string {
+	result := map[string][]string{}
+	s, ok := raw.(string)
+	if !ok || s == "" {
+		return result
+	}
+	decoded := map[string][]string{}
+	if err := json.Unmarshal([]byte(s), &decoded); err != nil {
+		return result
+	}
+	for k, v := range decoded {
+		result[k] = v
+	}
+	return result
+}
+
+// getCreateDefaults returns the data_json_create_defaults values
+// (attribute name -> values to inject on Create if absent from data_json).
+func getCreateDefaults(d *schema.ResourceData) map[string][]string {
+	return parseCreateDefaults(d.Get(attributeNameDataJsonCreateDefaults))
+}
+
+// appendCreateDefaultKeysToIgnore extends the ignore list so that
+// Read/Update paths treat data_json_create_defaults keys identically to
+// ignore_attributes. The Create path must NOT call this — if it did,
+// the injected defaults would be stripped back out before the LDAP Add.
+func appendCreateDefaultKeysToIgnore(ig *client.IgnoreAndBase64Encode, d *schema.ResourceData) {
+	for k := range getCreateDefaults(d) {
+		*ig.IgnoreAttributes = append(*ig.IgnoreAttributes, k)
+	}
+}
+
+// appendOldCreateDefaultKeysToIgnore mirrors appendCreateDefaultKeysToIgnore
+// against the pre-apply value of data_json_create_defaults so that keys
+// removed from it in the current plan are still stripped from the OLD
+// data_json before the add/delete/change-set diff is computed.
+func appendOldCreateDefaultKeysToIgnore(ig *client.IgnoreAndBase64Encode, d *schema.ResourceData) {
+	var raw interface{}
+	if d.HasChange(attributeNameDataJsonCreateDefaults) {
+		raw, _ = d.GetChange(attributeNameDataJsonCreateDefaults)
+	} else {
+		raw = d.Get(attributeNameDataJsonCreateDefaults)
+	}
+	for k := range parseCreateDefaults(raw) {
+		*ig.IgnoreAttributes = append(*ig.IgnoreAttributes, k)
+	}
 }

--- a/ldap/resource_entry.go
+++ b/ldap/resource_entry.go
@@ -143,6 +143,18 @@ func resourceLDAPEntry() *schema.Resource {
 				Optional:    true,
 				Elem:        &schema.Schema{Type: schema.TypeString},
 			},
+			attributeNameDataJsonCreateDefaults: {
+				Description: "JSON-encoded attribute values (same shape as data_json: attribute name -> list of values) injected on Create if the attribute is absent from data_json. Keys are also treated as ignore_attributes on Read and Update, so the attribute is never surfaced to state nor modified after initial creation. Intended for fields owned by an external system (e.g. a userPassword reset by Keycloak after the entry is created).",
+				Type:        schema.TypeString,
+				Optional:    true,
+				ValidateFunc: func(value interface{}, k string) (ws []string, errs []error) {
+					decoded := make(map[string][]string)
+					if err := json.Unmarshal([]byte(value.(string)), &decoded); err != nil {
+						errs = append(errs, err)
+					}
+					return nil, errs
+				},
+			},
 		},
 	}
 }
@@ -175,6 +187,7 @@ func resourceLDAPEntryRead(ctx context.Context, d *schema.ResourceData, m interf
 	dn := id
 	d.Set(attributeNameDn, dn)
 	ignoreAndBase64Encode := getIgnoreAndBase64encode(d)
+	appendCreateDefaultKeysToIgnore(ignoreAndBase64Encode, d)
 	ignoreRDNAttributes := client.GetRDNAttributes(ldapEntry, dn)
 	if ignoreRDNAttributes != nil {
 		*ignoreAndBase64Encode.IgnoreAttributes = append(*ignoreAndBase64Encode.IgnoreAttributes, *ignoreRDNAttributes...)
@@ -209,6 +222,11 @@ func resourceLDAPEntryCreate(ctx context.Context, d *schema.ResourceData, m inte
 		return diag.FromErr(err)
 	}
 	client.IgnoreAndBase64decodeAttributes(&ldapEntry, ignoreAndBase64Encode)
+	for key, values := range getCreateDefaults(d) {
+		if _, present := ldapEntry.Entry[key]; !present {
+			ldapEntry.Entry[key] = values
+		}
+	}
 	ldapEntry.Dn = dn
 
 	err = cl.CreateEntry(&ldapEntry)
@@ -227,7 +245,9 @@ func resourceLDAPEntryUpdate(ctx context.Context, d *schema.ResourceData, m inte
 	dn := d.Get(attributeNameDn).(string)
 
 	newIgnoreAndBase64Encode := getIgnoreAndBase64encode(d)
+	appendCreateDefaultKeysToIgnore(newIgnoreAndBase64Encode, d)
 	oldIgnoreAndBas64Encode := getOldIgnoreAndBase64encode(d)
+	appendOldCreateDefaultKeysToIgnore(oldIgnoreAndBas64Encode, d)
 	var err error
 	if d.HasChanges(attributeNameDataJson) {
 		oldDataJson, newDataJson := d.GetChange(attributeNameDataJson)

--- a/ldap/resource_entry_test.go
+++ b/ldap/resource_entry_test.go
@@ -180,6 +180,120 @@ resource "ldap_entry" "user_jimmit" {
 `)
 }
 
+func TestAccResourceLdapEntryCreateDefaults(t *testing.T) {
+	resource.UnitTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: providerFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccResourceEntryCreateDefaults("Street"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrWith(
+						"ldap_entry.user_defaults",
+						"data_json_create_defaults",
+						func(value string) error {
+							decoded := map[string][]string{}
+							if err := json.Unmarshal([]byte(value), &decoded); err != nil {
+								return err
+							}
+							vals, present := decoded["userPassword"]
+							if !present || len(vals) == 0 || vals[0] != "{SSHA}creation-dummy" {
+								return fmt.Errorf("data_json_create_defaults: expected userPassword=[\"{SSHA}creation-dummy\"], got %v", decoded)
+							}
+							return nil
+						},
+					),
+					resource.TestCheckResourceAttrWith(
+						"ldap_entry.user_defaults",
+						"data_json",
+						func(value string) error {
+							var e client.LdapEntry
+							if err := json.Unmarshal([]byte(value), &e.Entry); err != nil {
+								return err
+							}
+							if _, present := e.Entry["userPassword"]; present {
+								return errors.New("userPassword: expected to be stripped from resource data_json via data_json_create_defaults, got '" + e.Entry["userPassword"][0] + "'")
+							}
+							return nil
+						},
+					),
+					resource.TestCheckResourceAttrWith(
+						"data.ldap_entry.user_defaults",
+						"data_json",
+						func(value string) error {
+							var e client.LdapEntry
+							if err := json.Unmarshal([]byte(value), &e.Entry); err != nil {
+								return err
+							}
+							vals, present := e.Entry["userPassword"]
+							if !present {
+								return errors.New("userPassword: expected to be present on the LDAP server (injected by data_json_create_defaults), but data.ldap_entry did not return it")
+							}
+							if len(vals) == 0 || vals[0] != "{SSHA}creation-dummy" {
+								return fmt.Errorf("userPassword: expected '{SSHA}creation-dummy' on server, got %v", vals)
+							}
+							return nil
+						},
+					),
+				),
+			},
+			{
+				Config: testAccResourceEntryCreateDefaults("NewStreet"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrWith(
+						"ldap_entry.user_defaults",
+						"data_json",
+						func(value string) error {
+							var e client.LdapEntry
+							if err := json.Unmarshal([]byte(value), &e.Entry); err != nil {
+								return err
+							}
+							if len(e.Entry["street"]) == 0 || e.Entry["street"][0] != "NewStreet" {
+								return fmt.Errorf("street: expected 'NewStreet' after update, got %v", e.Entry["street"])
+							}
+							if _, present := e.Entry["userPassword"]; present {
+								return errors.New("userPassword: leaked into resource data_json after unrelated-attribute update")
+							}
+							return nil
+						},
+					),
+				),
+			},
+		},
+	})
+}
+
+func testAccResourceEntryCreateDefaults(street string) string {
+	return fmt.Sprintf(`
+resource "ldap_entry" "users_example_com" {
+  dn = "ou=users,dc=example,dc=com"
+  data_json = jsonencode({
+    objectClass = ["organizationalUnit"]
+  })
+}
+
+resource "ldap_entry" "user_defaults" {
+  dn = "uid=defaults01,${ldap_entry.users_example_com.dn}"
+  data_json_create_defaults = jsonencode({
+    userPassword = ["{SSHA}creation-dummy"]
+  })
+  data_json = jsonencode({
+    objectClass = ["inetOrgPerson"]
+    ou          = ["users"]
+    givenName   = ["Default"]
+    sn          = [ldap_entry.users_example_com.id]
+    cn          = ["Default User"]
+    street      = ["%s"]
+  })
+}
+
+data "ldap_entry" "user_defaults" {
+  depends_on = [ldap_entry.user_defaults]
+  dn         = ldap_entry.user_defaults.dn
+}
+`, street)
+}
+
 func testAccResourceEntryRestrictAttributes() string {
 	return fmt.Sprintf(`
 resource "ldap_entry" "users_example_com" {


### PR DESCRIPTION
Injects the given attribute values on Create if absent from data_json, and thereafter treats those keys like ignore_attributes on Read and Update. Intended for attributes owned by a downstream system — e.g. a userPassword that Keycloak resets after the entry is materialized — so Terraform places a dummy at creation time but never re-modifies the attribute.